### PR TITLE
Escape attributes even if no whitelist is configured for an element

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -365,7 +365,9 @@ export default class SanitizeState {
         const allowedAttrs: string[] | undefined = (wl.ATTRIBUTES as any)[elem.name];
         for (const attr of Object.keys(elem.attrs)) {
             // Check allowed attributes
-            if (allowedAttrs !== undefined && allowedAttrs.indexOf(attr) === -1 && !wl.ATTRIBUTES['*'].has(attr)) {
+            const isOwnAttr = allowedAttrs !== undefined && allowedAttrs.indexOf(attr) !== -1;
+            const isAllAttr = wl.ATTRIBUTES['*'].has(attr);
+            if (!isOwnAttr && !isAllAttr) {
                 return HowToSanitize.Escape;
             }
 

--- a/test/sanitize.ts
+++ b/test/sanitize.ts
@@ -280,6 +280,18 @@ test('sanitize unknown empty elements', t => {
     }
 });
 
+test('sanitize unknown attribute', t => {
+    for (const tc of [['<details ontoggle=f()>', '</details>']]) {
+        const state = new SanitizeState();
+        for (const tag of tc) {
+            const have = state.sanitize(tag);
+            const want = escape(tag);
+            t.is(want, have);
+        }
+        t.false(state.isInUse());
+    }
+})
+
 const TEST_REMOVE_OK = {
     'remove list item element if list element is not in ancestors': {
         input: [['<li>', '</li>'], ['<li/>']],

--- a/test/sanitize.ts
+++ b/test/sanitize.ts
@@ -290,7 +290,7 @@ test('sanitize unknown attribute', t => {
         }
         t.false(state.isInUse());
     }
-})
+});
 
 const TEST_REMOVE_OK = {
     'remove list item element if list element is not in ancestors': {


### PR DESCRIPTION
The logic for detecting that an attribute should be escaped consisted in:

    allowedAttrs !== undefined && 
    allowedAttrs.indexOf(attr) === -1 && 
    !wl.ATTRIBUTES['*'].has(attr)

For elements for which no `ATTRIBUTES` were configured (such as `<details>`) variable `allowedAttrs` would be undefined and cause the entire check to fail, mistakenly allowing any attributes (such as `<details ontoggle=foo()>`) without escaping them.

This commit fixes the logic, and splits the condition into named boolean variables to make it easier to verify.

It also includes `<details ontoggle=f()></details>` as a unit test.

Many thanks to https://twitter.com/BNaitsirhc for first discovering this issue.